### PR TITLE
Hotfixes snowflake compatability

### DIFF
--- a/macros/activity_stream/activity_stream.sql
+++ b/macros/activity_stream/activity_stream.sql
@@ -48,6 +48,11 @@
 
 
   -- setup
+  -- open with begin statement so that if failure occurs everything rolls back
+  {% call statement('begin', fetch_result=True) %}
+    begin;
+  {%- endcall -%}
+
   -- create temp relation and table if table materialization strategy or full_refresh flag
   {%- if full_refresh -%}
     {%- set tmp_identifier = identifier ~ '__dbt_activity_schema' ~ '_tmp' -%}
@@ -114,7 +119,7 @@
     {%- set main_activity_name = 'main-' ~ activity_name -%}
     {{ log('insert activity stream query: '~insert_activity_stream) }}
     {% call statement(main_activity_name, fetch_result=True) -%}
-      insert into {%- if full_refresh -%}{{tmp_relation}}{%- else -%}{{target_relation}}{%- endif -%} ({{insert_target_columns}})
+      insert into {% if full_refresh %}{{tmp_relation}}{% else %}{{target_relation}}{% endif %} ({{insert_target_columns}})
       (
           select
               {{insert_target_columns}}

--- a/macros/activity_stream/activity_stream_utils.sql
+++ b/macros/activity_stream/activity_stream_utils.sql
@@ -201,7 +201,7 @@ cluster by ({{activity_name_col}}, {{entity_id}})
 
 {% macro snowflake__get_cluster_keys(entity_id) %}
 {%- set activity_name_col = dbt_activity_schema.get_activity_name_col() -%}
-cluster by ({{activity_name_col}}, {{entity_id}})
+cluster by {{entity_id}}
 {% endmacro %}
 
 {% macro bigquery__get_cluster_keys(entity_id) %}

--- a/macros/dataset/parse_attribute.sql
+++ b/macros/dataset/parse_attribute.sql
@@ -51,6 +51,6 @@ cast(nullif({{dbt_activity_schema.parse_json('attributes', attribute)}}, '') as 
 {%- if attribute_name in ['activity_id', 'activity_at', entity_id] -%}
 {{coalesce_prefix}}{{attribute_name}}{{condition_str}}{{coalesce_suffix}}
 {%- else -%}
-{{coalesce_prefix}}cast(nullif({{dbt_activity_schema.parse_json('attributes', attribute_name)}}, ''){{condition_str}}as {{data_type}}){{coalesce_suffix}}
+{{coalesce_prefix}}cast(nullif({{dbt_activity_schema.parse_json('attributes', attribute_name)}}, '')as {{data_type}}){{condition_str}}{{coalesce_suffix}}
 {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
This PR:
* cleans up whitespace
* adds a transaction opening for compiling the activity stream
* fixes the order of operations in the `parse_attribute` macro
* updates the default cluster keys for the Snowflake activity stream
