### PR TITLE
add parentheses

### DIFF
--- a/macros/activity_stream/activity_stream_utils.sql
+++ b/macros/activity_stream/activity_stream_utils.sql
@@ -201,7 +201,7 @@ cluster by ({{activity_name_col}}, {{entity_id}})
 
 {% macro snowflake__get_cluster_keys(entity_id) %}
 {%- set activity_name_col = dbt_activity_schema.get_activity_name_col() -%}
-cluster by {{entity_id}}
+cluster by ({{entity_id}})
 {% endmacro %}
 
 {% macro bigquery__get_cluster_keys(entity_id) %}


### PR DESCRIPTION
This PR:
* fixes a bug where the `cluster by` statement was missing parentheses around the cluster keys
