### PR TITLE
include schema and db in query

### DIFF
--- a/macros/activity_stream/activity_stream.sql
+++ b/macros/activity_stream/activity_stream.sql
@@ -118,7 +118,7 @@
       (
           select
               {{insert_target_columns}}
-          from {{tmp_activity_relation.include(schema=False)}}
+          from {{tmp_activity_relation.include(schema=True, database=True)}}
       );
     {%- endcall %}
     {{ adapter.drop_relation(tmp_activity_relation) }}


### PR DESCRIPTION
This PR:
* updates a `relation.include` method to include the relation's database and schema