### PR TITLE
fix renamed relation

### DIFF
--- a/macros/activity_stream/activity_stream.sql
+++ b/macros/activity_stream/activity_stream.sql
@@ -143,7 +143,9 @@
   {{ log('tmp: '~tmp_relation) }}
   {%- if full_refresh -%}
   {# if full_refresh, then swap existing table with temp table #}
+    {%- if relation_exists -%}
     {{ adapter.rename_relation(old_relation, backup_relation) }}
+    {%- endif -%}
     {{ adapter.rename_relation(tmp_relation, target_relation) }}
     {{ adapter.drop_relation(backup_relation) }}
     {{ adapter.drop_relation(tmp_relation) }}


### PR DESCRIPTION
This PR:
* fixes a bug where a nonexistent relation was attempting to be renamed in cases where the relation did not previously exist.