### PR TITLE
use builtin

### DIFF
--- a/macros/dataset/compile_timestamp_join.sql
+++ b/macros/dataset/compile_timestamp_join.sql
@@ -3,7 +3,7 @@
 {%- endmacro -%}
 
 {%- macro default__early_timestamp() -%}
-    cast('100-01-01' as {{dbt_activity_schema.type_timestamp()}})
+    cast('100-01-01' as {{type_timestamp()}})
 {%- endmacro -%}
 
 


### PR DESCRIPTION
This PR:
* changes a reference to the `type_timestamp()` jinja function to use dbt's built-in version, instead of a non-existent package-specific implementation