### PR TITLE
Hotfix relationships

### DIFF
--- a/macros/activity_stream/activity_stream_utils.sql
+++ b/macros/activity_stream/activity_stream_utils.sql
@@ -140,6 +140,24 @@ vacuum {{relation}}
 {% endmacro %}
 
 
+{% macro get_activity_occurrence_col() %}
+    {{ return(adapter.dispatch('get_activity_occurrence_col', 'dbt_activity_schema')()) }}
+{% endmacro %}
+
+{% macro default__get_activity_occurrence_col() %}
+    {{ return('activity_occurrence') }}
+{% endmacro %}
+
+
+{% macro get_activity_repeated_at_col() %}
+    {{ return(adapter.dispatch('get_activity_repeated_at_col', 'dbt_activity_schema')()) }}
+{% endmacro %}
+
+{% macro default__get_activity_repeated_at_col() %}
+    {{ return('activity_repeated_at') }}
+{% endmacro %}
+
+
 {% macro get_activity_stream_schema(entity_id) %}
     {{ return(adapter.dispatch('get_activity_stream_schema', 'dbt_activity_schema')(entity_id)) }}
 {% endmacro %}
@@ -148,6 +166,8 @@ vacuum {{relation}}
 {%- set activity_ts_col = dbt_activity_schema.get_activity_ts_col() -%}
 {%- set activity_id_col = dbt_activity_schema.get_activity_id_col() -%}
 {%- set activity_name_col = dbt_activity_schema.get_activity_name_col() -%}
+{%- set activity_occurrence_col = dbt_activity_schema.get_activity_occurrence_col() -%}
+{%- set activity_repeated_at_col = dbt_activity_schema.get_activity_repeated_at_col() -%}
 {%- set attribues_col = dbt_activity_schema.get_attributes_col() -%}
 {%- set loaded_at_col = dbt_activity_schema.get_loaded_at_col() -%}
 {%- set base_columns = {
@@ -156,6 +176,8 @@ vacuum {{relation}}
     activity_name_col: {'data_type': type_string(), 'sql': activity_name_col},
     activity_ts_col: {'data_type': type_timestamp(), 'sql': activity_ts_col},
     attribues_col: {'data_type': dbt_activity_schema.type_json(), 'sql': attribues_col},
+    activity_occurrence_col: {'data_type': type_int(), 'sql': activity_occurrence_col},
+    activity_repeated_at_col: {'data_type': type_timestamp(), 'sql': activity_repeated_at_col},
     loaded_at_col: {'data_type': type_timestamp(), 'sql': current_timestamp()}
 } -%}
     {{ return(base_columns) }}

--- a/macros/activity_stream/activity_stream_utils.sql
+++ b/macros/activity_stream/activity_stream_utils.sql
@@ -220,6 +220,18 @@ compound sortkey({{entity_id}}, {{activity_name_col}}, {{activity_ts_col}})
 -- noop - not supporting for now
 {% endmacro %}
 
+{% macro transient() %}
+    {{ return(adapter.dispatch('transient', 'dbt_activity_schema')()) }}
+{% endmacro %}
+
+{% macro default__transient() %}
+
+{% endmacro %}
+
+{% macro snowflake__transient() %}
+transient
+{% endmacro %}
+
 {% macro create_empty_activity_stream(entity_id, relation) -%}
     {{ return(adapter.dispatch('create_empty_activity_stream', 'dbt_activity_schema')(entity_id, relation)) }}
 {% endmacro %}
@@ -227,7 +239,7 @@ compound sortkey({{entity_id}}, {{activity_name_col}}, {{activity_ts_col}})
 {% macro default__create_empty_activity_stream(entity_id, relation) %}
 {%- set base_columns = dbt_activity_schema.get_activity_stream_schema(entity_id=entity_id) -%}
 
-create table {{relation.include(database=true)}} (
+create {{dbt_activity_schema.transient()}} table {{relation.include(database=true)}} (
 {% for key in base_columns.keys() %}
     {% if not loop.first %}, {% endif %}{{key}} {{base_columns[key]['data_type']}}
 {% endfor %}

--- a/macros/activity_stream/activity_stream_utils.sql
+++ b/macros/activity_stream/activity_stream_utils.sql
@@ -223,7 +223,7 @@ cluster by ({{activity_name_col}}, {{entity_id}})
 
 {% macro snowflake__get_cluster_keys(entity_id) %}
 {%- set activity_name_col = dbt_activity_schema.get_activity_name_col() -%}
-cluster by ({{entity_id}})
+cluster by (activity_name, activity_occurrence in (1, NULL), activity_repeated_at is NULL, to_date(activity_at))
 {% endmacro %}
 
 {% macro bigquery__get_cluster_keys(entity_id) %}

--- a/macros/activity_stream/activity_stream_utils.sql
+++ b/macros/activity_stream/activity_stream_utils.sql
@@ -54,7 +54,7 @@ cluster by activity_name, {{entity_id}}
 {% endmacro %}
 
 {% macro snowflake__get_cluster_statement(entity_id) %}
-cluster by activity_name, {{entity_id}}
+cluster by (activity_name, activity_occurrence in (1, NULL), activity_repeated_at is NULL, to_date(activity_at))
 {% endmacro %}
 
 {% macro bigquery__get_cluster_statement(entity_id) %}

--- a/macros/aggregation/build_aggregation.sql
+++ b/macros/aggregation/build_aggregation.sql
@@ -8,8 +8,10 @@
 {%- set aggfunc = config.require('aggfunc') -%}
 {%- set after_timestamp = config.require('after_timestamp') -%}
 {%- set before_timestamp = config.require('before_timestamp') -%}
+{%- set relationship = config.require('relationship') -%}
 {%- set condition = config.get('condition', default=none) -%}
 {%- set backup_value = config.get('backup_value', default=none) -%}
+{%- set relationships = dbt_activity_schema._get_relationships() -%}
 
   {%- if execute -%}
     {# confirm aggregation materialization #}
@@ -41,7 +43,16 @@
       {%- endset -%}
       {{ exceptions.raise_compiler_error(error_message) }}
     {%- endif -%}
+
+    {# confirm valid relationship is specified #}
+    {%- if relationship not in relationships.keys() -%}
+        {%- set error_message -%}
+        Relationship '{{ relationship }}' is invalid for model '{{ model.unique_id }}'. Please specify a valid option from {{ relationships.keys() | join(', ') }}
+        {%- endset -%}
+        {{ exceptions.raise_compiler_error(error_message) }}
+    {%- endif -%}
   {%- endif -%}
+
 
 
 {{"-- depends_on: "~activity_stream}}

--- a/macros/dataset/relationship/_get_relationships.sql
+++ b/macros/dataset/relationship/_get_relationships.sql
@@ -1,0 +1,21 @@
+{% macro _get_relationships() %}
+
+{%- set relationships = {
+    'first_ever': dbt_activity_schema.join_first_ever,
+    'last_ever': dbt_activity_schema.join_last_ever,
+    'nth_ever': dbt_activity_schema.join_nth_ever,
+    'first_before': dbt_activity_schema.join_first_before,
+    'last_before': dbt_activity_schema.join_last_before,
+    'first_after': dbt_activity_schema.join_first_after,
+    'last_after': dbt_activity_schema.join_last_after,
+    'first_in_between': dbt_activity_schema.join_first_in_between,
+    'last_in_between': dbt_activity_schema.join_last_in_between,
+    'aggregate_all_ever': dbt_activity_schema.join_aggregate_all_ever,
+    'aggregate_before': dbt_activity_schema.join_aggregate_before,
+    'aggregate_after': dbt_activity_schema.join_aggregate_after,
+    'aggregate_in_between': dbt_activity_schema.join_aggregate_in_between,
+} -%}
+
+{%- do return(relationships) -%}
+
+{% endmacro %}

--- a/macros/dataset/relationship/compile_relationship_join.sql
+++ b/macros/dataset/relationship/compile_relationship_join.sql
@@ -1,0 +1,24 @@
+{%- macro compile_relationship_join(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    relationship,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) -%}
+
+{%- set relationships = dbt_activity_schema._get_relationships() -%}
+{%- set relationship_join = relationships.get(relationship)(
+    primary_activity=primary_activity,
+    primary_cte=primary_cte,
+    secondary_activity=secondary_activity,
+    secondary_alias=secondary_alias,
+    nth_occurrence=nth_occurrence,
+    after_timestamp=after_timestamp,
+    before_timestamp=before_timestamp
+)-%}
+{{relationship_join}}
+
+{%- endmacro -%}

--- a/macros/dataset/relationship/join_aggregate_after.sql
+++ b/macros/dataset/relationship/join_aggregate_after.sql
@@ -1,0 +1,11 @@
+{% macro join_aggregate_after(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at > {{primary_cte}}.{{primary_activity}}_activity_at
+{% endmacro %}

--- a/macros/dataset/relationship/join_aggregate_all_ever.sql
+++ b/macros/dataset/relationship/join_aggregate_all_ever.sql
@@ -1,0 +1,11 @@
+{% macro join_aggregate_all_ever(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+
+{% endmacro %}

--- a/macros/dataset/relationship/join_aggregate_before.sql
+++ b/macros/dataset/relationship/join_aggregate_before.sql
@@ -1,0 +1,11 @@
+{% macro join_aggregate_before(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at < {{primary_cte}}.{{primary_activity}}_activity_at
+{% endmacro %}

--- a/macros/dataset/relationship/join_aggregate_in_between.sql
+++ b/macros/dataset/relationship/join_aggregate_in_between.sql
@@ -1,0 +1,15 @@
+{% macro join_aggregate_in_between(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at > {{primary_cte}}.{{primary_activity}}_activity_at
+and (
+    {{secondary_alias}}.{{secondary_activity}}_activity_at <= {{primary_cte}}.{{primary_activity}}_activity_repeated_at
+    or {{primary_cte}}.{{primary_activity}}_activity_repeated_at is null
+)
+{% endmacro %}

--- a/macros/dataset/relationship/join_custom.sql
+++ b/macros/dataset/relationship/join_custom.sql
@@ -1,0 +1,16 @@
+{% macro join_custom(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+{% if after_timestamp is not none -%}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at >= {{after_timestamp}}
+{% endif %}
+{% if before_timestamp is not none -%}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at <= {{before_timestamp}}
+{% endif %}
+{% endmacro %}

--- a/macros/dataset/relationship/join_first_after.sql
+++ b/macros/dataset/relationship/join_first_after.sql
@@ -1,0 +1,11 @@
+{% macro join_first_after(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at > {{primary_cte}}.{{primary_activity}}_activity_at
+{% endmacro %}

--- a/macros/dataset/relationship/join_first_before.sql
+++ b/macros/dataset/relationship/join_first_before.sql
@@ -1,0 +1,12 @@
+{% macro join_first_before(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at < {{primary_cte}}.{{primary_activity}}_activity_at
+and {{secondary_alias}}.{{secondary_activity}}_activity_occurrence = 1
+{% endmacro %}

--- a/macros/dataset/relationship/join_first_ever.sql
+++ b/macros/dataset/relationship/join_first_ever.sql
@@ -1,0 +1,11 @@
+{% macro join_first_ever(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_occurrence = 1
+{% endmacro %}

--- a/macros/dataset/relationship/join_first_in_between.sql
+++ b/macros/dataset/relationship/join_first_in_between.sql
@@ -1,0 +1,15 @@
+{% macro join_first_in_between(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at > {{primary_cte}}.{{primary_activity}}_activity_at
+and (
+    {{secondary_alias}}.{{secondary_activity}}_activity_at <= {{primary_cte}}.{{primary_activity}}_activity_repeated_at
+    or {{primary_cte}}.{{primary_activity}}_activity_repeated_at is null
+)
+{% endmacro %}

--- a/macros/dataset/relationship/join_last_after.sql
+++ b/macros/dataset/relationship/join_last_after.sql
@@ -1,0 +1,12 @@
+{% macro join_last_after(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at > {{primary_cte}}.{{primary_activity}}_activity_at
+and {{secondary_alias}}.{{secondary_activity}}_activity_repeated_at is null
+{% endmacro %}

--- a/macros/dataset/relationship/join_last_before.sql
+++ b/macros/dataset/relationship/join_last_before.sql
@@ -1,0 +1,11 @@
+{% macro join_last_before(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at < {{primary_cte}}.{{primary_activity}}_activity_at
+{% endmacro %}

--- a/macros/dataset/relationship/join_last_ever.sql
+++ b/macros/dataset/relationship/join_last_ever.sql
@@ -1,0 +1,11 @@
+{% macro join_last_ever(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_repeated_at is null
+{% endmacro %}

--- a/macros/dataset/relationship/join_last_in_between.sql
+++ b/macros/dataset/relationship/join_last_in_between.sql
@@ -1,0 +1,15 @@
+{% macro join_last_in_between(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at > {{primary_cte}}.{{primary_activity}}_activity_at
+and (
+    {{secondary_alias}}.{{secondary_activity}}_activity_at <= {{primary_cte}}.{{primary_activity}}_activity_repeated_at
+    or {{primary_cte}}.{{primary_activity}}_activity_repeated_at is null
+)
+{% endmacro %}

--- a/macros/dataset/relationship/join_nth_ever.sql
+++ b/macros/dataset/relationship/join_nth_ever.sql
@@ -1,0 +1,11 @@
+{% macro join_nth_ever(
+    primary_activity,
+    primary_cte,
+    secondary_activity,
+    secondary_alias,
+    nth_occurrence=none,
+    after_timestamp=none,
+    before_timestamp=none
+) %}
+and {{secondary_alias}}.{{secondary_activity}}_activity_occurrence = {{nth_occurrence}}
+{% endmacro %}


### PR DESCRIPTION
This PR:
* adds functionality to support relationships in aggregation definitions
* updates the `dataset` macro to use relationships when defining join logic to append aggregations
* updates `build_activity` to include `activity_occurrence` and `activity_repeated_at` columns
* forces all materialized activity stream tables to be transient
* updates cluster keys based on the Activity Schema spec