### PR TITLE
add custom to relationships registry

### DIFF
--- a/macros/dataset/relationship/_get_relationships.sql
+++ b/macros/dataset/relationship/_get_relationships.sql
@@ -14,6 +14,7 @@
     'aggregate_before': dbt_activity_schema.join_aggregate_before,
     'aggregate_after': dbt_activity_schema.join_aggregate_after,
     'aggregate_in_between': dbt_activity_schema.join_aggregate_in_between,
+    'custom': dbt_activity_schema.join_custom,
 } -%}
 
 {%- do return(relationships) -%}


### PR DESCRIPTION
This PR:
* fixes an error where the `custom` relationship type was not properly registered to the `_get_relationships` registry macro