### PR TITLE
Hotfix agg all ever join performance

### DIFF
--- a/macros/dataset/build_dataset.sql
+++ b/macros/dataset/build_dataset.sql
@@ -217,7 +217,7 @@ with {{primary_cte}} as (
         {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
         , {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_activity_id
     {% else %}
-        {{alias}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
+        {{alias}}.{{secondary_activity}}_{{entity_id}}
     {% endif %}
         {%- for sm in join_reqs['aggregations'] %}
         , {{sm['aggregation_sql']}} as {{sm['aggregation_name']}}
@@ -225,7 +225,6 @@ with {{primary_cte}} as (
     {% if join_reqs['relationship'] != 'aggregate_all_ever' %}
     from {{primary_cte}}
     left join {{se['cte']}} {{alias}}
-        on {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}} = {{alias}}.{{secondary_activity}}_{{entity_id}}
         on {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}} = {{alias}}.{{secondary_activity}}_{{entity_id}}
         {{ dbt_activity_schema.compile_relationship_join(
             primary_activity=dbt_activity_schema.remove_prefix(sql_graph['primary_activity']),
@@ -239,12 +238,13 @@ with {{primary_cte}} as (
         ) }}
     {% else %}
     from {{se['cte']}} {{alias}}
+    {% endif %}
     group by
         {% if join_reqs['relationship'] != 'aggregate_all_ever' %}
             {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
             , {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_activity_id
         {% else %}
-            {{alias}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
+            {{alias}}.{{secondary_activity}}_{{entity_id}}
         {% endif %}
 )
 {% endfor -%}
@@ -273,7 +273,8 @@ with {{primary_cte}} as (
     {% if join_reqs['relationship'] != 'aggregate_all_ever' %}
         on {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_activity_id = {{alias}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_activity_id
     {% else %}
-        on {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}} = {{alias}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
+        on {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}} = {{alias}}.{{secondary_activity}}_{{entity_id}}
+    {% endif %}
     {% endfor %}
     {%- endfor -%}
 

--- a/macros/dataset/build_dataset.sql
+++ b/macros/dataset/build_dataset.sql
@@ -210,16 +210,22 @@ with {{primary_cte}} as (
 {%- set se = sql_graph['secondary_activities'][secondary_activity] -%}
 {%- for j in se['joins'].keys() -%}
 {%- set join_reqs = se['joins'][j] -%}
-, {{join_reqs['table_alias']}} as (
+{%- set alias = join_reqs['table_alias'] %}
+, {{alias}} as (
     select
+    {% if join_reqs['relationship'] != 'aggregate_all_ever' %}
         {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
         , {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_activity_id
+    {% else %}
+        {{alias}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
+    {% endif %}
         {%- for sm in join_reqs['aggregations'] %}
         , {{sm['aggregation_sql']}} as {{sm['aggregation_name']}}
         {%- endfor %}
+    {% if join_reqs['relationship'] != 'aggregate_all_ever' %}
     from {{primary_cte}}
-    {%- set alias = join_reqs['table_alias'] %}
     left join {{se['cte']}} {{alias}}
+        on {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}} = {{alias}}.{{secondary_activity}}_{{entity_id}}
         on {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}} = {{alias}}.{{secondary_activity}}_{{entity_id}}
         {{ dbt_activity_schema.compile_relationship_join(
             primary_activity=dbt_activity_schema.remove_prefix(sql_graph['primary_activity']),
@@ -231,9 +237,15 @@ with {{primary_cte}} as (
             after_timestamp=join_reqs['after_ts'],
             before_timestamp=join_reqs['before_ts']
         ) }}
+    {% else %}
+    from {{se['cte']}} {{alias}}
     group by
-        {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
-        , {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_activity_id
+        {% if join_reqs['relationship'] != 'aggregate_all_ever' %}
+            {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
+            , {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_activity_id
+        {% else %}
+            {{alias}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
+        {% endif %}
 )
 {% endfor -%}
 {%- endfor -%}
@@ -258,7 +270,10 @@ with {{primary_cte}} as (
     {%- set join_reqs = se['joins'][j] -%}
     {%- set alias = join_reqs['table_alias'] -%}
     left join {{alias}}
+    {% if join_reqs['relationship'] != 'aggregate_all_ever' %}
         on {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_activity_id = {{alias}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_activity_id
+    {% else %}
+        on {{primary_cte}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}} = {{alias}}.{{dbt_activity_schema.remove_prefix(sql_graph['primary_activity'])}}_{{entity_id}}
     {% endfor %}
     {%- endfor -%}
 


### PR DESCRIPTION
This PR:
* adds a fix to improve performance of aggregations computed for activities appended with the `aggregate_all_ever` relationship
