### PR TITLE
add custom parsing of primary activity timestamp for custom relationships

### DIFF
--- a/macros/dataset/relationship/join_custom.sql
+++ b/macros/dataset/relationship/join_custom.sql
@@ -8,9 +8,11 @@
     before_timestamp=none
 ) %}
 {% if after_timestamp is not none -%}
-and {{secondary_alias}}.{{secondary_activity}}_activity_at >= {{after_timestamp}}
+{%- set after_timestap_formatted = after_timestamp.format(primary_activity_at=primary_cte~'.'~primary_activity~'_activity_at') -%}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at >= {{after_timestamp_formatted}}
 {% endif %}
 {% if before_timestamp is not none -%}
-and {{secondary_alias}}.{{secondary_activity}}_activity_at <= {{before_timestamp}}
+{%- set before_timestap_formatted = before_timestamp.format(primary_activity_at=primary_cte~'.'~primary_activity~'_activity_at') -%}
+and {{secondary_alias}}.{{secondary_activity}}_activity_at <= {{before_timestamp_formatted}}
 {% endif %}
 {% endmacro %}

--- a/macros/dataset/relationship/join_custom.sql
+++ b/macros/dataset/relationship/join_custom.sql
@@ -8,11 +8,11 @@
     before_timestamp=none
 ) %}
 {% if after_timestamp is not none -%}
-{%- set after_timestap_formatted = after_timestamp.format(primary_activity_at=primary_cte~'.'~primary_activity~'_activity_at') -%}
+{%- set after_timestamp_formatted = after_timestamp.format(primary_activity_at=primary_cte~'.'~primary_activity~'_activity_at') -%}
 and {{secondary_alias}}.{{secondary_activity}}_activity_at >= {{after_timestamp_formatted}}
 {% endif %}
 {% if before_timestamp is not none -%}
-{%- set before_timestap_formatted = before_timestamp.format(primary_activity_at=primary_cte~'.'~primary_activity~'_activity_at') -%}
+{%- set before_timestamp_formatted = before_timestamp.format(primary_activity_at=primary_cte~'.'~primary_activity~'_activity_at') -%}
 and {{secondary_alias}}.{{secondary_activity}}_activity_at <= {{before_timestamp_formatted}}
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This PR:
* adds support to specify the primary activity timestamp column in the timestamp join criteria for aggregations using a custom relationship